### PR TITLE
Default to search if URL is malformed

### DIFF
--- a/xpfe/browser/resources/content/navigator.js
+++ b/xpfe/browser/resources/content/navigator.js
@@ -2165,8 +2165,26 @@ function handleURLBarRevert()
   return isScrolling; 
 }
 
+
+
+function isURL(str) {
+  return (str.indexOf("\.") != -1 || str.indexOf(":") != -1) && str.indexOf("?") != 0;
+	//return true;
+}
+
+
+
 function handleURLBarCommand(aUserAction, aTriggeringEvent)
 {
+  if(!isURL(gURLBar.value))
+  {
+		var searchstr = gURLBar.value;
+		if(searchstr.indexOf("?") == 0)
+		searchstr = searchstr.substr(1);
+		//alert("not a valid url defaulting to search");
+		OpenSearch(null, searchstr, false, false);
+		return;
+  }
   try {
     addToUrlbarHistory(gURLBar.value);
   } catch (ex) {


### PR DESCRIPTION
Changed /xpfe/browser/resources/content/navigator.js to add search fallback for malformed URLs. URL check may need to be improved, but it works without issue as of now.